### PR TITLE
feat(update): add min-age git history resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ sk sync gemini claude -n
 ## Features
 
 - **Add from GitHub** — Fetch skills directly from GitHub repositories with `sk add`
-- **Update from Upstream** — Check and apply upstream changes to downloaded skills with `sk update`
+- **Update from Upstream** — Check and apply upstream changes to downloaded skills with `sk update`, optionally pinning to the newest version at least N days old via `--min-age`
 - **List Skills** — List all skills across agents with `sk list`
 - **Skill Info** — View skill metadata and source links with `sk info`
 - **Provenance Tracking** — `add` / `download` record the source in `_from` (as `owner/repo@shortHash`, 7-char SHA by default; use `--full-hash` for full 40-char SHA). For skills, `sync` preserves `_from` only when the source skill already has it; commands may still record source provenance. Disable writing or copying with `--no-provenance`
@@ -88,6 +88,10 @@ sk sync gemini claude -n
 ### What does `_from` mean, and when should I use `--no-provenance`?
 
 `_from` records where a skill came from (typically `owner/repo@shortHash`) so you can trace local copies if an upstream public skill is later found to be compromised. `add` / `download` generate it from the upstream repository, while skill `sync` only copies an existing `_from` from the source skill. Command sync remains separate and may still record source provenance. Use **`--no-provenance`** when you do not want that metadata written or copied into frontmatter—for example, internal mirrors or policies that discourage embedding repository references.
+
+### What does `--min-age` do?
+
+`--min-age <days>` selects the newest version whose **committer timestamp** is at least that many days old. `sk add`, `sk download`, and `sk update` all use the same Git-history-based resolution. That means `sk update --min-age 14` may intentionally **re-pin** a local skill from today's HEAD back to an older stable version if the latest commit is still too new.
 
 ### Why does `sk` write under my repo instead of `~/.claude`?
 
@@ -112,20 +116,24 @@ Yes. The [Agent Skills](https://agentskills.io/) standard is shared across tools
 ```bash
 sk add https://github.com/anthropics/skills/tree/main/skills/skill-creator
 sk add <url> gemini                       # Place in Gemini skill directory
+sk add <url> --min-age 14                # Use the newest version at least 14 days old
 sk add <url> -g                           # Keep the original agent path, but under your home directory
 sk add <url> claude -g                    # Place in global Claude directory
 sk add <url> -n                           # Preview without downloading
 ```
 
-#### GitHub Authentication
+`add` / `download` resolve content through a local bare Git cache (`git clone --bare --filter=blob:none`), so tree selection and `_from` hashes come from Git history even when `--min-age` is not set.
 
-For private repositories, set a [personal access token](https://github.com/settings/tokens?type=beta):
+#### Git Authentication
+
+For private repositories, make sure your local `git` can authenticate to GitHub. Examples:
 
 ```bash
-export GITHUB_TOKEN=ghp_...
+gh auth setup-git
+# or configure your SSH key / credential helper
 ```
 
-**Token permissions**: Public repositories require no permissions. For private repositories, grant **Contents: Read** access to the target repository.
+If `git clone` / `git fetch` already works for the repository, `sk add` and `sk update` will use the same credentials.
 
 ### `sk update [skill-path]` — Update downloaded skills from upstream
 
@@ -133,9 +141,17 @@ export GITHUB_TOKEN=ghp_...
 sk update                                 # Check and update all agent skills
 sk update .claude/skills/my-skill         # Update a specific skill
 sk update skills/                         # Update all skills under a path
+sk update --min-age 7                     # Use the newest version at least 7 days old
 sk update -g                              # Target user-level directories instead
 sk update -n                              # Check for updates without applying
 ```
+
+With `--min-age`, update results can be:
+
+- `Updated`: moved to a newer eligible tree
+- `Re-pinned`: moved from a too-new HEAD tree back to an older eligible tree
+- `Already eligible`: local `_from` already points at the selected eligible tree
+- `Skipped: no eligible version found`: no commit for that skill is old enough yet
 
 ### `sk list` (alias: `sk ls`) — List skills across all agents
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -74,7 +74,7 @@ sk sync gemini claude -n
 ## 機能
 
 - **GitHub から追加** — `sk add` で GitHub リポジトリからスキルを直接取得
-- **上流からの更新** — `sk update` でダウンロード済みスキルの上流変更をチェックし適用
+- **上流からの更新** — `sk update` でダウンロード済みスキルの上流変更をチェックし適用。`--min-age` で「公開後 N 日以上経過した版のうち最新」に固定可能
 - **スキル一覧** — `sk list` で全エージェントのスキルを一覧表示
 - **スキル情報表示** — `sk info` でスキルのメタ情報とソースリンクを確認
 - **来歴トラッキング** — `add` / `download` はソース情報を `_from` に記録します（`owner/repo@shortHash` 形式、デフォルト 7 文字の短縮 SHA。`--full-hash` でフル 40 文字 SHA も選択可能）。skills の `sync` は変換元スキルがすでに `_from` を持っている場合だけそれを保持し、commands は従来どおりソース来歴を記録する場合があります。書き込みやコピーを抑止するには `--no-provenance`
@@ -88,6 +88,10 @@ sk sync gemini claude -n
 ### `_from` は何を表し、`--no-provenance` はいつ使えばよいのですか？
 
 `_from` はスキルの取得元（通常は `owner/repo@shortHash`）を記録し、公開スキルに問題があったときにローカルへ影響があるか追跡しやすくします。`add` / `download` は upstream リポジトリからこれを生成し、skill の `sync` は変換元スキルにすでにある `_from` だけをコピーします。command の `sync` は別で、従来どおりソース来歴を記録する場合があります。**`--no-provenance`** は、そのようなメタデータをフロントマターに書き込みまたはコピーしたくないときに使います。社内向けの複製や、リポジトリ参照を残したくないポリシーがある場合などです。
+
+### `--min-age` は何をするオプションですか？
+
+`--min-age <days>` は、「committer timestamp がその日数以上前の commit の中で最新の版」を選びます。`sk add`、`sk download`、`sk update` はすべて同じ Git 履歴ベースの解決を使うため、`sk update --min-age 14` では、最新の HEAD が新しすぎる場合に、より古い安定版へ **re-pin** されることがあります。
 
 ### なぜ `~/.claude` ではなく、リポジトリ配下に書き込まれるのですか？
 
@@ -114,20 +118,24 @@ sk sync gemini claude -n
 ```bash
 sk add https://github.com/anthropics/skills/tree/main/skills/skill-creator
 sk add <url> gemini                       # Gemini のスキルディレクトリに配置
+sk add <url> --min-age 14                # 14日以上経過した版のうち最新を使う
 sk add <url> -g                           # 元のエージェントのパスを保ったままホームディレクトリ配下に配置
 sk add <url> claude -g                    # グローバル Claude ディレクトリに配置
 sk add <url> -n                           # ダウンロードせずにプレビュー
 ```
 
-#### GitHub 認証
+`add` / `download` はローカルの bare Git cache（`git clone --bare --filter=blob:none`）を使って取得するため、`--min-age` 未指定時も Git 履歴ベースで tree を選び、`_from` を生成します。
 
-プライベートリポジトリからダウンロードするには [Personal access token](https://github.com/settings/tokens?type=beta) を設定してください。
+#### Git 認証
+
+プライベートリポジトリを扱う場合は、ローカルの `git` が GitHub に認証できる状態にしてください。例:
 
 ```bash
-export GITHUB_TOKEN=ghp_...
+gh auth setup-git
+# または SSH キー / credential helper を利用
 ```
 
-**トークン権限**: パブリックリポジトリは権限設定不要です。プライベートリポジトリの場合、対象リポジトリに **Contents: Read** 権限を付与してください。
+`git clone` や `git fetch` がそのリポジトリに対して通るなら、`sk add` / `sk update` も同じ認証経路を使います。
 
 ### `sk update [skill-path]` — ダウンロード済みスキルを上流から更新
 
@@ -135,9 +143,17 @@ export GITHUB_TOKEN=ghp_...
 sk update                                 # 全エージェントスキルをチェック＆更新
 sk update .claude/skills/my-skill         # 特定のスキルを更新
 sk update skills/                         # パス配下の全スキルを更新
+sk update --min-age 7                     # 7日以上経過した版のうち最新を使う
 sk update -g                              # 代わりにユーザーレベルのディレクトリを対象にする
 sk update -n                              # 更新チェックのみ（適用なし）
 ```
+
+`--min-age` 指定時の主な結果は次のとおりです。
+
+- `Updated`: より新しい eligible tree に更新
+- `Re-pinned`: 新しすぎる HEAD から、より古い eligible tree に戻す
+- `Already eligible`: すでに選ばれた eligible tree を参照している
+- `Skipped: no eligible version found`: 条件を満たす commit がまだない
 
 ### `sk list`（エイリアス: `sk ls`）— スキル一覧を表示
 

--- a/src/cli/download.ts
+++ b/src/cli/download.ts
@@ -15,17 +15,21 @@ import {
 } from "../utils/file-utils.js";
 import {
   type DiscoveredSkill,
-  type DownloadedFile,
   type ParsedGitHubUrl,
   type ParsedRepoUrl,
   extractSkillName,
-  fetchDefaultBranch,
-  fetchSkillDirectory,
-  fetchSkillFromTree,
   parseGitHubUrl,
-  scanRepositoryForSkills,
   tryParseRepoUrl,
 } from "../utils/github-utils.js";
+import {
+  ensureGitHubRepoCache,
+  getSkillAtPath,
+  listSkillsAtRef,
+  readSkillFilesAtCommit,
+  resolveCommitForPath,
+  resolveDefaultBranch,
+  resolveTreeHashAtCommit,
+} from "../utils/git-repo-cache.js";
 
 // ── Types ───────────────────────────────────────────────────────
 
@@ -33,13 +37,13 @@ export interface DownloadOptions {
   url: string;
   destination?: ProductType;
   global: boolean;
-  githubToken?: string;
   noop: boolean;
   verbose: boolean;
   gitRoot?: string | null;
   customDirs?: Partial<Record<ProductType, string>>;
   noProvenance?: boolean;
   fullHash?: boolean;
+  minAge?: number;
 }
 
 // ── Operation display ───────────────────────────────────────────
@@ -136,7 +140,10 @@ export async function determineOperation(filePath: string, newContent: string | 
 /**
  * Write a single downloaded file to disk
  */
-export async function writeDownloadedFile(filePath: string, file: DownloadedFile): Promise<void> {
+export async function writeDownloadedFile(
+  filePath: string,
+  file: { content: string | Buffer; relativePath: string },
+): Promise<void> {
   await ensureDirectory(dirname(filePath));
   if (Buffer.isBuffer(file.content)) {
     await fs.writeFile(filePath, file.content);
@@ -182,10 +189,52 @@ function resolveTargetDirForRepoSkill(skill: DiscoveredSkill, options: DownloadO
   return join(resolveDownloadBaseDir(options), skill.path);
 }
 
+async function resolveTargetRef(
+  owner: string,
+  repo: string,
+  requestedRef?: string,
+): Promise<{ repoDir: string; ref: string }> {
+  const cache = await ensureGitHubRepoCache(owner, repo);
+  const ref = requestedRef ?? (await resolveDefaultBranch(cache.dir));
+  return { repoDir: cache.dir, ref };
+}
+
+async function resolveDownloadedSkillFiles(
+  repoDir: string,
+  ref: string,
+  skillPath: string,
+  minAge?: number,
+): Promise<{ files: Awaited<ReturnType<typeof readSkillFilesAtCommit>>; treeHash: string; commitSha: string } | null> {
+  const commitSha = await resolveCommitForPath(repoDir, ref, skillPath, minAge);
+  if (!commitSha) {
+    return null;
+  }
+
+  const treeHash = await resolveTreeHashAtCommit(repoDir, commitSha, skillPath);
+  if (!treeHash) {
+    return null;
+  }
+
+  const files = await readSkillFilesAtCommit(repoDir, commitSha, skillPath);
+  if (!files.some((file) => file.relativePath === SKILL_CONSTANTS.SKILL_FILE_NAME)) {
+    return null;
+  }
+
+  return { files, treeHash, commitSha };
+}
+
+function printNoEligibleWarning(skillLabel: string, options: DownloadOptions): void {
+  const ageLabel = options.minAge === undefined ? "" : ` for min-age=${options.minAge}d`;
+  console.log(
+    `  ${picocolors.yellow("[!]")} ${skillLabel} - ${picocolors.yellow(`Skipped: no eligible version found${ageLabel}`)}`,
+  );
+}
+
 /**
  * Download all skills found in a repository.
  */
 async function downloadMultipleSkills(
+  repoDir: string,
   repoUrl: ParsedRepoUrl & { ref: string },
   skills: DiscoveredSkill[],
   options: DownloadOptions,
@@ -204,12 +253,17 @@ async function downloadMultipleSkills(
 
   for (const skill of skills) {
     try {
-      // Use raw.githubusercontent.com to avoid API rate limits
-      const files = await fetchSkillFromTree(repoUrl.owner, repoUrl.repo, ref, skill);
+      const resolved = await resolveDownloadedSkillFiles(repoDir, ref, skill.path, options.minAge);
+      if (!resolved) {
+        printNoEligibleWarning(skill.path, options);
+        continue;
+      }
+
+      const files = resolved.files;
       const targetDir = resolveTargetDirForRepoSkill(skill, options);
 
       if (!options.noProvenance) {
-        const fromValue = formatFromValue(ownerRepo, skill.treeHash, options.fullHash);
+        const fromValue = formatFromValue(ownerRepo, resolved.treeHash, options.fullHash);
         for (const file of files) {
           if (file.relativePath === SKILL_CONSTANTS.SKILL_FILE_NAME && typeof file.content === "string") {
             file.content = injectFromUrl(file.content, fromValue);
@@ -307,20 +361,14 @@ export async function downloadSkill(options: DownloadOptions): Promise<void> {
   // 1. Check for repo-level URL first
   const repoUrl = tryParseRepoUrl(options.url);
   if (repoUrl) {
-    const ref = repoUrl.ref ?? (await fetchDefaultBranch(repoUrl.owner, repoUrl.repo, options.githubToken));
+    const { repoDir, ref } = await resolveTargetRef(repoUrl.owner, repoUrl.repo, repoUrl.ref);
     const resolvedRepoUrl = { ...repoUrl, ref };
 
     if (options.verbose) {
       console.log(`DEBUG: Repository URL detected: ${repoUrl.owner}/${repoUrl.repo} ref=${ref}`);
     }
 
-    const { skills, truncated } = await scanRepositoryForSkills(repoUrl.owner, repoUrl.repo, ref, options.githubToken);
-
-    if (truncated) {
-      console.log(
-        picocolors.yellow("Warning: Repository tree was truncated by GitHub API. Some skills may not be found."),
-      );
-    }
+    const skills = await listSkillsAtRef(repoDir, ref);
 
     if (skills.length === 0) {
       throw new Error(
@@ -332,7 +380,7 @@ export async function downloadSkill(options: DownloadOptions): Promise<void> {
       console.log(`DEBUG: Found ${skills.length} skills: ${skills.map((s) => s.path).join(", ")}`);
     }
 
-    await downloadMultipleSkills(resolvedRepoUrl, skills, options);
+    await downloadMultipleSkills(repoDir, resolvedRepoUrl, skills, options);
     return;
   }
 
@@ -350,11 +398,24 @@ export async function downloadSkill(options: DownloadOptions): Promise<void> {
     `\nDownloading skill from ${picocolors.cyan(`github.com/${parsed.owner}/${parsed.repo}`)}... ${picocolors.dim(modeLabel)}${dryRunLabel}`,
   );
 
-  // 3. Fetch files from GitHub
-  const { files, treeHash } = await fetchSkillDirectory(parsed, options.githubToken);
+  const { repoDir, ref } = await resolveTargetRef(parsed.owner, parsed.repo, parsed.ref);
+  const skill = await getSkillAtPath(repoDir, ref, parsed.path);
+  if (!skill) {
+    throw new Error(
+      `SKILL.md not found in ${parsed.path}. Make sure the URL points to a valid skill directory containing SKILL.md.`,
+    );
+  }
+
+  const resolved = await resolveDownloadedSkillFiles(repoDir, ref, parsed.path, options.minAge);
+  if (!resolved) {
+    printNoEligibleWarning(parsed.path, options);
+    return;
+  }
+
+  const { files, treeHash } = resolved;
 
   if (options.verbose) {
-    console.log(`DEBUG: Fetched ${files.length} files`);
+    console.log(`DEBUG: Fetched ${files.length} files from ${resolved.commitSha}`);
   }
 
   // 4. Determine target directory

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -97,6 +97,14 @@ function registerCommonDirOptions(cmd: Command): Command {
   return cmd;
 }
 
+function parseMinAge(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error("--min-age must be a non-negative integer number of days");
+  }
+  return parsed;
+}
+
 /** Print help text. Concise when detailed=false, full when detailed=true. */
 function printHelp(detailed: boolean): void {
   const desc = `Download, update, and sync AI agent skills across ${displayNames}`;
@@ -136,8 +144,10 @@ function printHelp(detailed: boolean): void {
   console.log("\nExamples:");
   console.log("  $ sk add <github-url>               # Add a skill from GitHub");
   console.log("  $ sk add <github-url> gemini        # Add into Gemini skill directory");
+  console.log("  $ sk add <github-url> --min-age 14  # Use the newest version at least 14 days old");
   console.log("  $ sk add <github-repo-url>          # Bulk add all skills from a repo");
   console.log("  $ sk update                         # Update all downloaded skills");
+  console.log("  $ sk update --min-age 7             # Use the newest version at least 7 days old");
   console.log("  $ sk update .claude/skills/my-skill  # Update a specific skill");
   console.log("  $ sk list                            # List all skills");
   console.log("  $ sk list -g                         # List global (user-level) skills");
@@ -192,6 +202,7 @@ async function main(): Promise<void> {
     .description("Download skill(s) from GitHub (supports repo-level bulk download)")
     .option("-n, --noop", "Preview files without downloading", false)
     .option("-v, --verbose", "Show detailed debug information", false)
+    .option("--min-age <days>", "Use the newest version at least N days old", parseMinAge)
     .option("--no-provenance", "Do not write or copy _from provenance in frontmatter")
     .option("--full-hash", "Use full 40-character tree hash in _from provenance", false);
 
@@ -203,13 +214,13 @@ async function main(): Promise<void> {
         url,
         destination: to as ProductType | undefined,
         global: options.global,
-        githubToken: process.env.GITHUB_TOKEN,
         noop: options.noop,
         verbose: options.verbose,
         gitRoot,
         customDirs: buildCustomDirs(options),
         noProvenance: !options.provenance,
         fullHash: options.fullHash,
+        minAge: options.minAge,
       });
     } catch (error) {
       handleError(error);
@@ -223,6 +234,7 @@ async function main(): Promise<void> {
     .description("Check for and apply upstream updates to downloaded skills")
     .option("-n, --noop", "Check for updates without applying them", false)
     .option("-v, --verbose", "Show detailed debug information", false)
+    .option("--min-age <days>", "Use the newest version at least N days old", parseMinAge)
     .option("--full-hash", "Use full 40-character tree hash in _from provenance", false);
 
   registerCommonDirOptions(updateCmd);
@@ -237,6 +249,7 @@ async function main(): Promise<void> {
         global: options.global,
         customDirs: buildCustomDirs(options),
         fullHash: options.fullHash,
+        minAge: options.minAge,
       });
     } catch (error) {
       handleError(error);

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -6,7 +6,14 @@ import { AGENT_REGISTRY } from "../agents/registry.js";
 import { PRODUCT_TYPES, type ProductType } from "../types/intermediate.js";
 import { SKILL_CONSTANTS } from "../utils/constants.js";
 import { type DirResolutionContext, fileExists, findAgentSkills, readFile } from "../utils/file-utils.js";
-import { fetchDefaultBranch, fetchSkillFromTree, scanRepositoryForSkills } from "../utils/github-utils.js";
+import {
+  ensureGitHubRepoCache,
+  listSkillsAtRef,
+  readSkillFilesAtCommit,
+  resolveCommitForPath,
+  resolveDefaultBranch,
+  resolveTreeHashAtCommit,
+} from "../utils/git-repo-cache.js";
 import { formatFromValue, injectFromUrl, writeDownloadedFile } from "./download.js";
 
 // ── Types ───────────────────────────────────────────────────────
@@ -19,6 +26,7 @@ export interface UpdateOptions {
   gitRoot?: string | null;
   customDirs?: Partial<Record<ProductType, string>>;
   fullHash?: boolean;
+  minAge?: number;
 }
 
 export interface LocalSkillInfo {
@@ -200,8 +208,7 @@ export async function updateSkills(options: UpdateOptions): Promise<void> {
   }
 
   // 3. Process each repo
-  const token = process.env.GITHUB_TOKEN;
-  const stats = { updated: 0, upToDate: 0, notFound: 0, error: 0 };
+  const stats = { updated: 0, repinned: 0, upToDate: 0, noEligible: 0, notFound: 0, error: 0 };
 
   for (const [ownerRepo, skills] of byRepo) {
     const [owner, repo] = ownerRepo.split("/");
@@ -209,17 +216,14 @@ export async function updateSkills(options: UpdateOptions): Promise<void> {
     console.log(`\n  ${picocolors.cyan(ownerRepo)}:`);
 
     try {
-      const defaultBranch = await fetchDefaultBranch(owner, repo, token);
+      const cache = await ensureGitHubRepoCache(owner, repo);
+      const defaultBranch = await resolveDefaultBranch(cache.dir);
 
       if (options.verbose) {
         console.log(`  DEBUG: Default branch: ${defaultBranch}`);
       }
 
-      const { skills: remoteSkills, truncated } = await scanRepositoryForSkills(owner, repo, defaultBranch, token);
-
-      if (truncated) {
-        console.log(picocolors.yellow("    Warning: Repository tree was truncated. Some skills may not be found."));
-      }
+      const remoteSkills = await listSkillsAtRef(cache.dir, defaultBranch);
 
       if (options.verbose) {
         console.log(
@@ -228,10 +232,10 @@ export async function updateSkills(options: UpdateOptions): Promise<void> {
       }
 
       for (const local of skills) {
-        const remote = remoteSkills.find((s) => s.name === local.skillName);
         const displayPath = getDisplayPath(local, options);
+        const matches = remoteSkills.filter((s) => s.name === local.skillName);
 
-        if (!remote) {
+        if (matches.length === 0) {
           console.log(
             `    ${picocolors.gray("[?]")} ${local.skillName} ${picocolors.dim(`(${displayPath})`)} - ${picocolors.gray("Not found in remote")}`,
           );
@@ -239,31 +243,64 @@ export async function updateSkills(options: UpdateOptions): Promise<void> {
           continue;
         }
 
-        // Compare tree hashes
-        const remoteHash = remote.treeHash ?? "";
-        if (local.localTreeHash !== "" && hashesMatch(local.localTreeHash, remoteHash)) {
+        if (matches.length > 1) {
           console.log(
-            `    ${picocolors.blue("[=]")} ${local.skillName} ${picocolors.dim(`(${displayPath})`)} - ${picocolors.blue("No upstream changes")}`,
+            `    ${picocolors.yellow("[!]")} ${local.skillName} ${picocolors.dim(`(${displayPath})`)} - ${picocolors.yellow("Skipped: multiple remote skills share this name")}`,
+          );
+          stats.error++;
+          continue;
+        }
+
+        const remote = matches[0];
+        const headTreeHash = remote.treeHash ?? "";
+        const eligibleCommit = await resolveCommitForPath(cache.dir, defaultBranch, remote.path, options.minAge);
+
+        if (!eligibleCommit) {
+          console.log(
+            `    ${picocolors.yellow("[!]")} ${local.skillName} ${picocolors.dim(`(${displayPath})`)} - ${picocolors.yellow("Skipped: no eligible version found")}`,
+          );
+          stats.noEligible++;
+          continue;
+        }
+
+        const eligibleTreeHash = await resolveTreeHashAtCommit(cache.dir, eligibleCommit, remote.path);
+        if (!eligibleTreeHash) {
+          console.log(
+            `    ${picocolors.red("[!]")} ${local.skillName} ${picocolors.dim(`(${displayPath})`)} - ${picocolors.red("Error: failed to resolve eligible tree hash")}`,
+          );
+          stats.error++;
+          continue;
+        }
+
+        if (local.localTreeHash !== "" && hashesMatch(local.localTreeHash, eligibleTreeHash)) {
+          console.log(
+            `    ${picocolors.blue("[=]")} ${local.skillName} ${picocolors.dim(`(${displayPath})`)} - ${picocolors.blue("Already eligible")}`,
           );
           stats.upToDate++;
           continue;
         }
 
-        // Need update
+        const repinned =
+          headTreeHash !== "" &&
+          hashesMatch(local.localTreeHash, headTreeHash) &&
+          !hashesMatch(eligibleTreeHash, headTreeHash);
+
         if (options.noop) {
           console.log(
-            `    ${picocolors.yellow("[M]")} ${local.skillName} ${picocolors.dim(`(${displayPath})`)} - ${picocolors.yellow("Update available")}`,
+            `    ${picocolors.yellow("[M]")} ${local.skillName} ${picocolors.dim(`(${displayPath})`)} - ${picocolors.yellow(repinned ? "Would re-pin" : "Update available")}`,
           );
-          stats.updated++;
+          if (repinned) {
+            stats.repinned++;
+          } else {
+            stats.updated++;
+          }
           continue;
         }
 
-        // Download and update
         try {
-          const files = await fetchSkillFromTree(owner, repo, defaultBranch, remote);
+          const files = await readSkillFilesAtCommit(cache.dir, eligibleCommit, remote.path);
 
-          // Inject updated _from with new tree hash
-          const fromValue = formatFromValue(ownerRepo, remote.treeHash, options.fullHash);
+          const fromValue = formatFromValue(ownerRepo, eligibleTreeHash, options.fullHash);
           for (const file of files) {
             if (file.relativePath === SKILL_CONSTANTS.SKILL_FILE_NAME && typeof file.content === "string") {
               file.content = injectFromUrl(file.content, fromValue);
@@ -277,9 +314,13 @@ export async function updateSkills(options: UpdateOptions): Promise<void> {
           }
 
           console.log(
-            `    ${picocolors.yellow("[M]")} ${local.skillName} ${picocolors.dim(`(${displayPath})`)} - ${picocolors.yellow("Updated")}`,
+            `    ${picocolors.yellow("[M]")} ${local.skillName} ${picocolors.dim(`(${displayPath})`)} - ${picocolors.yellow(repinned ? "Re-pinned" : "Updated")}`,
           );
-          stats.updated++;
+          if (repinned) {
+            stats.repinned++;
+          } else {
+            stats.updated++;
+          }
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           console.log(
@@ -301,7 +342,10 @@ export async function updateSkills(options: UpdateOptions): Promise<void> {
   if (options.noop) {
     if (stats.updated > 0)
       parts.push(picocolors.yellow(`${stats.updated} update${stats.updated !== 1 ? "s" : ""} available`));
-    if (stats.upToDate > 0) parts.push(picocolors.blue(`${stats.upToDate} unchanged`));
+    if (stats.repinned > 0)
+      parts.push(picocolors.yellow(`${stats.repinned} re-pin${stats.repinned !== 1 ? "s" : ""} available`));
+    if (stats.upToDate > 0) parts.push(picocolors.blue(`${stats.upToDate} already eligible`));
+    if (stats.noEligible > 0) parts.push(picocolors.yellow(`${stats.noEligible} with no eligible version`));
     if (stats.notFound > 0) parts.push(picocolors.gray(`${stats.notFound} not found`));
     if (stats.error > 0) parts.push(picocolors.red(`${stats.error} error${stats.error !== 1 ? "s" : ""}`));
     if (parts.length > 0) console.log(`${parts.join(", ")}.`);
@@ -309,7 +353,10 @@ export async function updateSkills(options: UpdateOptions): Promise<void> {
   } else {
     if (stats.updated > 0)
       parts.push(picocolors.yellow(`${stats.updated} skill${stats.updated !== 1 ? "s" : ""} updated`));
-    if (stats.upToDate > 0) parts.push(picocolors.blue(`${stats.upToDate} unchanged`));
+    if (stats.repinned > 0)
+      parts.push(picocolors.yellow(`${stats.repinned} skill${stats.repinned !== 1 ? "s" : ""} re-pinned`));
+    if (stats.upToDate > 0) parts.push(picocolors.blue(`${stats.upToDate} already eligible`));
+    if (stats.noEligible > 0) parts.push(picocolors.yellow(`${stats.noEligible} with no eligible version`));
     if (stats.notFound > 0) parts.push(picocolors.gray(`${stats.notFound} not found`));
     if (stats.error > 0) parts.push(picocolors.red(`${stats.error} error${stats.error !== 1 ? "s" : ""}`));
     if (parts.length > 0) console.log(`Done! ${parts.join(", ")}.`);

--- a/src/utils/git-repo-cache.ts
+++ b/src/utils/git-repo-cache.ts
@@ -1,0 +1,252 @@
+import { execFile } from "node:child_process";
+import { mkdir, rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, extname, join } from "node:path";
+import { promisify } from "node:util";
+import type { DiscoveredSkill, DownloadedFile } from "./github-utils.js";
+
+const execFileAsync = promisify(execFile);
+const LOCK_RETRY_MS = 100;
+const LOCK_TIMEOUT_MS = 60_000;
+
+interface GitExecOptions {
+  cwd?: string;
+  encoding?: "utf8" | "buffer";
+}
+
+function getCacheBaseDir(): string {
+  const xdgCacheHome = process.env.XDG_CACHE_HOME;
+  return xdgCacheHome ? join(xdgCacheHome, "agent-skill-porter") : join(homedir(), ".cache", "agent-skill-porter");
+}
+
+export function getRepoCacheDir(owner: string, repo: string): string {
+  return join(getCacheBaseDir(), "repos", `${owner.toLowerCase()}_${repo.toLowerCase()}.git`);
+}
+
+function getGitHubRemoteUrl(owner: string, repo: string): string {
+  return `https://github.com/${owner}/${repo}.git`;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withRepoLock<T>(repoDir: string, fn: () => Promise<T>): Promise<T> {
+  const lockDir = `${repoDir}.lock`;
+  const startedAt = Date.now();
+
+  while (true) {
+    try {
+      await mkdir(lockDir);
+      break;
+    } catch (error) {
+      if (Date.now() - startedAt >= LOCK_TIMEOUT_MS) {
+        throw new Error(`Timed out waiting for repository lock after 60 seconds: ${lockDir}`);
+      }
+      await sleep(LOCK_RETRY_MS);
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    await rm(lockDir, { recursive: true, force: true });
+  }
+}
+
+async function runGit(args: string[], options: GitExecOptions = {}): Promise<string | Buffer> {
+  try {
+    const result = await execFileAsync("git", args, {
+      cwd: options.cwd,
+      encoding: options.encoding === "buffer" ? null : "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return result.stdout;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(`git ${args.join(" ")} failed: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+async function runGitText(args: string[], cwd?: string): Promise<string> {
+  const result = await runGit(args, { cwd, encoding: "utf8" });
+  return String(result);
+}
+
+async function runGitBuffer(args: string[], cwd?: string): Promise<Buffer> {
+  const result = await runGit(args, { cwd, encoding: "buffer" });
+  return Buffer.isBuffer(result) ? result : Buffer.from(String(result));
+}
+
+export interface CachedRepository {
+  owner: string;
+  repo: string;
+  dir: string;
+}
+
+export async function ensureGitHubRepoCache(owner: string, repo: string): Promise<CachedRepository> {
+  const dir = getRepoCacheDir(owner, repo);
+  const remoteUrl = getGitHubRemoteUrl(owner, repo);
+  await mkdir(dirname(dir), { recursive: true });
+
+  await withRepoLock(dir, async () => {
+    const exists = await (async () => {
+      try {
+        await runGitText(["rev-parse", "--git-dir"], dir);
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+
+    if (!exists) {
+      await runGitText(["clone", "--bare", "--filter=blob:none", remoteUrl, dir]);
+    } else {
+      await runGitText(["fetch", "--prune", "--filter=blob:none", "origin"], dir);
+      try {
+        await runGitText(["remote", "set-head", "origin", "--auto"], dir);
+      } catch {
+        // Best-effort only. Some remotes do not expose HEAD in a way this can update.
+      }
+    }
+  });
+
+  return { owner, repo, dir };
+}
+
+export async function resolveDefaultBranch(repoDir: string): Promise<string> {
+  try {
+    const stdout = await runGitText(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], repoDir);
+    return stdout.trim().replace(/^origin\//, "");
+  } catch {
+    try {
+      await runGitText(["remote", "set-head", "origin", "--auto"], repoDir);
+      const stdout = await runGitText(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], repoDir);
+      return stdout.trim().replace(/^origin\//, "");
+    } catch {
+      const stdout = await runGitText(["symbolic-ref", "--short", "HEAD"], repoDir);
+      return stdout.trim();
+    }
+  }
+}
+
+export async function resolveCommitForPath(
+  repoDir: string,
+  ref: string,
+  skillPath: string,
+  minAgeDays?: number,
+): Promise<string | null> {
+  if (minAgeDays === undefined) {
+    const stdout = await runGitText(["rev-parse", `${ref}^{commit}`], repoDir);
+    return stdout.trim() || null;
+  }
+
+  const cutoffUnixSeconds = Math.floor((Date.now() - minAgeDays * 24 * 60 * 60 * 1000) / 1000);
+  try {
+    const stdout = await runGitText(["log", "--format=%ct%x00%H", ref, "--", skillPath], repoDir);
+    const lines = stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    for (const line of lines) {
+      const [timestampText, commitSha] = line.split("\0");
+      const timestamp = Number.parseInt(timestampText, 10);
+      if (Number.isNaN(timestamp) || !commitSha) {
+        continue;
+      }
+      if (timestamp <= cutoffUnixSeconds) {
+        return commitSha;
+      }
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveTreeHashAtCommit(
+  repoDir: string,
+  commitSha: string,
+  skillPath: string,
+): Promise<string | null> {
+  try {
+    const stdout = await runGitText(["rev-parse", `${commitSha}:${skillPath}`], repoDir);
+    const hash = stdout.trim();
+    return /^[0-9a-f]{40}$/.test(hash) ? hash : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function listSkillsAtRef(repoDir: string, ref: string): Promise<DiscoveredSkill[]> {
+  const stdout = await runGitText(["ls-tree", "-r", "--name-only", "-z", ref], repoDir);
+  const files = stdout
+    .split("\0")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const skillPaths = files
+    .filter((file) => file.endsWith("/SKILL.md"))
+    .map((file) => file.slice(0, -"/SKILL.md".length));
+
+  const skills: DiscoveredSkill[] = [];
+  for (const skillPath of skillPaths) {
+    const prefix = `${skillPath}/`;
+    const skillFiles = files.filter((file) => file.startsWith(prefix));
+    const segments = skillPath.split("/");
+    const treeHash = await resolveTreeHashAtCommit(repoDir, ref, skillPath);
+    skills.push({
+      path: skillPath,
+      name: segments[segments.length - 1],
+      files: skillFiles,
+      treeHash: treeHash ?? undefined,
+    });
+  }
+
+  return skills.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export async function getSkillAtPath(repoDir: string, ref: string, skillPath: string): Promise<DiscoveredSkill | null> {
+  const skills = await listSkillsAtRef(repoDir, ref);
+  return skills.find((skill) => skill.path === skillPath) ?? null;
+}
+
+function isBinaryFile(path: string): boolean {
+  const ext = extname(path).toLowerCase();
+  return [".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".pdf", ".zip", ".gz", ".wasm"].includes(ext);
+}
+
+export async function readSkillFilesAtCommit(
+  repoDir: string,
+  commitSha: string,
+  skillPath: string,
+): Promise<DownloadedFile[]> {
+  const stdout = await runGitText(["ls-tree", "-r", "--name-only", "-z", commitSha, skillPath], repoDir);
+  const files = stdout
+    .split("\0")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const prefix = `${skillPath}/`;
+  const downloaded: DownloadedFile[] = [];
+
+  for (const filePath of files) {
+    const relativePath = filePath.startsWith(prefix) ? filePath.slice(prefix.length) : filePath;
+    const binary = isBinaryFile(relativePath);
+    const content = binary
+      ? await runGitBuffer(["show", `${commitSha}:${filePath}`], repoDir)
+      : await runGitText(["show", `${commitSha}:${filePath}`], repoDir);
+
+    downloaded.push({
+      relativePath,
+      content,
+      isBinary: binary,
+    });
+  }
+
+  return downloaded;
+}

--- a/tests/cli/download.test.ts
+++ b/tests/cli/download.test.ts
@@ -2,41 +2,77 @@ import { writeFile as fsWriteFile, mkdir, readFile, rm } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import matter from "gray-matter";
-import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { downloadSkill, formatFromValue } from "../../src/cli/download.js";
-import type { DownloadedFile, GitHubContentItem } from "../../src/utils/github-utils.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DiscoveredSkill } from "../../src/utils/github-utils.js";
+
+vi.mock("../../src/utils/git-repo-cache.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/utils/git-repo-cache.js")>();
+  return {
+    ...actual,
+    ensureGitHubRepoCache: vi.fn(),
+    getSkillAtPath: vi.fn(),
+    listSkillsAtRef: vi.fn(),
+    readSkillFilesAtCommit: vi.fn(),
+    resolveCommitForPath: vi.fn(),
+    resolveDefaultBranch: vi.fn(),
+    resolveTreeHashAtCommit: vi.fn(),
+  };
+});
+
+import { downloadSkill } from "../../src/cli/download.js";
+import {
+  ensureGitHubRepoCache,
+  getSkillAtPath,
+  listSkillsAtRef,
+  readSkillFilesAtCommit,
+  resolveCommitForPath,
+  resolveDefaultBranch,
+  resolveTreeHashAtCommit,
+} from "../../src/utils/git-repo-cache.js";
 
 describe("download command", () => {
-  let originalFetch: typeof globalThis.fetch;
-  let mockFetch: Mock;
   let tempDir: string;
   let consoleOutput: string[];
   let originalHome: string | undefined;
 
   beforeEach(async () => {
-    // Clear gray-matter cache to prevent cross-test pollution
     (matter as unknown as { clearCache: () => void }).clearCache();
 
-    // Set up temp directory
     tempDir = join(tmpdir(), `download-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     await mkdir(tempDir, { recursive: true });
 
-    // Mock fetch
-    originalFetch = globalThis.fetch;
-    mockFetch = vi.fn();
-    globalThis.fetch = mockFetch;
-
-    // Capture console output
     consoleOutput = [];
     vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
       consoleOutput.push(args.join(" "));
     });
 
     originalHome = process.env.HOME;
+
+    vi.mocked(ensureGitHubRepoCache).mockResolvedValue({ owner: "owner", repo: "repo", dir: "/cache/repo.git" });
+    vi.mocked(resolveDefaultBranch).mockResolvedValue("main");
+    vi.mocked(resolveCommitForPath).mockResolvedValue("commit-1");
+    vi.mocked(resolveTreeHashAtCommit).mockResolvedValue("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2");
+    vi.mocked(readSkillFilesAtCommit).mockResolvedValue([
+      { relativePath: "SKILL.md", content: "---\ndescription: My Skill\n---\n# My Skill", isBinary: false },
+      { relativePath: "helper.ts", content: "export function helper() {}", isBinary: false },
+    ]);
+    vi.mocked(getSkillAtPath).mockResolvedValue({
+      name: "my-skill",
+      path: ".claude/skills/my-skill",
+      files: [".claude/skills/my-skill/SKILL.md", ".claude/skills/my-skill/helper.ts"],
+      treeHash: "headtree",
+    });
+    vi.mocked(listSkillsAtRef).mockResolvedValue([
+      {
+        name: "my-skill",
+        path: ".claude/skills/my-skill",
+        files: [".claude/skills/my-skill/SKILL.md", ".claude/skills/my-skill/helper.ts"],
+        treeHash: "headtree",
+      },
+    ]);
   });
 
   afterEach(async () => {
-    globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
     if (originalHome === undefined) {
       process.env.HOME = undefined;
@@ -48,60 +84,7 @@ describe("download command", () => {
 
   const testUrl = "https://github.com/owner/repo/tree/main/.claude/skills/my-skill";
 
-  function mockDirectoryListing(items: Partial<GitHubContentItem>[]): Response {
-    return {
-      ok: true,
-      status: 200,
-      json: async () =>
-        items.map((item) => ({
-          name: item.name ?? "file.txt",
-          path: item.path ?? `.claude/skills/my-skill/${item.name}`,
-          type: item.type ?? "file",
-          size: item.size ?? 100,
-          sha: item.sha ?? "abc123",
-          download_url:
-            item.download_url ??
-            `https://raw.githubusercontent.com/owner/repo/main/.claude/skills/my-skill/${item.name}`,
-          ...item,
-        })),
-      headers: new Headers(),
-    } as Response;
-  }
-
-  function mockFileContent(content: string): Response {
-    return {
-      ok: true,
-      status: 200,
-      text: async () => content,
-      arrayBuffer: async () => new TextEncoder().encode(content).buffer,
-      headers: new Headers(),
-    } as Response;
-  }
-
-  /** Mock response for the parent directory fetch (tree hash retrieval) */
-  function mockParentDirResponse(treeHash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"): Response {
-    return mockDirectoryListing([
-      { name: "my-skill", type: "dir", path: ".claude/skills/my-skill", sha: treeHash, download_url: null },
-    ]);
-  }
-
-  function setupBasicMocks() {
-    mockFetch
-      .mockResolvedValueOnce(
-        mockDirectoryListing([
-          { name: "SKILL.md", type: "file" },
-          { name: "helper.ts", type: "file" },
-        ]),
-      )
-      .mockResolvedValueOnce(mockFileContent("---\ndescription: My Skill\n---\n# My Skill"))
-      .mockResolvedValueOnce(mockFileContent("export function helper() {}"))
-      // Parent directory fetch (for tree hash)
-      .mockResolvedValueOnce(mockParentDirResponse());
-  }
-
-  it("should download skill to project-level path based on URL (default)", async () => {
-    setupBasicMocks();
-
+  it("should download a single skill to the project-level path by default", async () => {
     await downloadSkill({
       url: testUrl,
       global: false,
@@ -110,39 +93,15 @@ describe("download command", () => {
       gitRoot: tempDir,
     });
 
-    // Check files were created at the URL path relative to gitRoot
     const skillMd = await readFile(join(tempDir, ".claude/skills/my-skill/SKILL.md"), "utf-8");
-    // SKILL.md should have _from injected with owner/repo format
-    expect(skillMd).toContain("_from:");
-    expect(skillMd).toContain("owner/repo");
-    expect(skillMd).toContain("description: My Skill");
+    const parsed = matter(skillMd);
+    expect(parsed.data._from).toBe("owner/repo@a1b2c3d");
 
     const helperTs = await readFile(join(tempDir, ".claude/skills/my-skill/helper.ts"), "utf-8");
     expect(helperTs).toBe("export function helper() {}");
   });
 
-  it("should download skill to agent-specific directory with -d option", async () => {
-    setupBasicMocks();
-
-    await downloadSkill({
-      url: testUrl,
-      destination: "gemini",
-      global: false,
-      noop: false,
-      verbose: false,
-      gitRoot: tempDir,
-      customDirs: { gemini: tempDir },
-    });
-
-    // With -d gemini and customDir=tempDir, files go to tempDir/skills/my-skill/
-    const skillMd = await readFile(join(tempDir, "skills/my-skill/SKILL.md"), "utf-8");
-    expect(skillMd).toContain("description: My Skill");
-    expect(skillMd).toContain("owner/repo");
-  });
-
-  it("should download to cwd-based project directory when destination is set outside a git repository", async () => {
-    setupBasicMocks();
-
+  it("should use the destination agent directory outside a git repository", async () => {
     const originalCwd = process.cwd();
     process.chdir(tempDir);
 
@@ -161,12 +120,9 @@ describe("download command", () => {
 
     const skillMd = await readFile(join(tempDir, ".gemini/skills/my-skill/SKILL.md"), "utf-8");
     expect(skillMd).toContain("description: My Skill");
-    expect(skillMd).toContain("owner/repo");
   });
 
   it("should not write files in noop mode", async () => {
-    setupBasicMocks();
-
     await downloadSkill({
       url: testUrl,
       global: false,
@@ -175,18 +131,12 @@ describe("download command", () => {
       gitRoot: tempDir,
     });
 
-    // Directory should not exist
-    const { fileExists } = await import("../../src/utils/file-utils.js");
-    expect(await fileExists(join(tempDir, ".claude/skills/my-skill/SKILL.md"))).toBe(false);
-
-    // Should show dry run messages
-    const output = consoleOutput.join("\n");
-    expect(output).toContain("would create");
-    expect(output).toContain("Dry run complete");
+    await expect(readFile(join(tempDir, ".claude/skills/my-skill/SKILL.md"), "utf-8")).rejects.toThrow();
+    expect(consoleOutput.join("\n")).toContain("would create");
   });
 
-  it("should show [A] for new files", async () => {
-    setupBasicMocks();
+  it("should skip a single skill when no eligible version exists for min-age", async () => {
+    vi.mocked(resolveCommitForPath).mockResolvedValue(null);
 
     await downloadSkill({
       url: testUrl,
@@ -194,57 +144,61 @@ describe("download command", () => {
       noop: false,
       verbose: false,
       gitRoot: tempDir,
+      minAge: 30,
     });
 
-    const output = consoleOutput.join("\n");
-    expect(output).toContain("Created");
-    expect(output).toContain("2 files created");
-    expect(output).toContain("1 skill created");
+    expect(consoleOutput.join("\n")).toContain("no eligible version found");
+    await expect(readFile(join(tempDir, ".claude/skills/my-skill/SKILL.md"), "utf-8")).rejects.toThrow();
   });
 
-  it("should show [M] for modified files", async () => {
-    // Pre-create existing file with different content
-    const skillDir = join(tempDir, ".claude/skills/my-skill");
-    await mkdir(skillDir, { recursive: true });
-    await fsWriteFile(join(skillDir, "SKILL.md"), "old content", "utf-8");
-    await fsWriteFile(join(skillDir, "helper.ts"), "old helper", "utf-8");
+  it("should download repo skills and skip only the ones without an eligible version", async () => {
+    const repoUrl = "https://github.com/owner/repo";
+    const repoSkills: DiscoveredSkill[] = [
+      {
+        name: "my-skill",
+        path: ".claude/skills/my-skill",
+        files: [".claude/skills/my-skill/SKILL.md"],
+        treeHash: "headtree-1",
+      },
+      {
+        name: "other-skill",
+        path: ".claude/skills/other-skill",
+        files: [".claude/skills/other-skill/SKILL.md"],
+        treeHash: "headtree-2",
+      },
+    ];
 
-    setupBasicMocks();
+    vi.mocked(listSkillsAtRef).mockResolvedValue(repoSkills);
+    vi.mocked(resolveCommitForPath).mockImplementation(async (_repoDir, _ref, skillPath) =>
+      skillPath.includes("other-skill") ? null : "commit-1",
+    );
+    vi.mocked(resolveTreeHashAtCommit).mockResolvedValue("feedbeef0123456789abcdef0123456789abcdef");
+    vi.mocked(readSkillFilesAtCommit).mockImplementation(async (_repoDir, _commitSha, skillPath) => [
+      {
+        relativePath: "SKILL.md",
+        content: `---\ndescription: ${skillPath.split("/").pop()}\n---\n# Skill`,
+        isBinary: false,
+      },
+    ]);
 
     await downloadSkill({
-      url: testUrl,
+      url: repoUrl,
+      destination: "gemini",
       global: false,
       noop: false,
       verbose: false,
       gitRoot: tempDir,
+      minAge: 14,
     });
 
-    const output = consoleOutput.join("\n");
-    expect(output).toContain("Updated");
-    expect(output).toContain("2 files updated");
-    expect(output).toContain("1 skill updated");
+    const created = await readFile(join(tempDir, ".gemini/skills/my-skill/SKILL.md"), "utf-8");
+    expect(created).toContain("_from: owner/repo@feedbee");
+    await expect(readFile(join(tempDir, ".gemini/skills/other-skill/SKILL.md"), "utf-8")).rejects.toThrow();
+    expect(consoleOutput.join("\n")).toContain("other-skill -");
+    expect(consoleOutput.join("\n")).toContain("no eligible version found");
   });
 
-  it("should inject _from with owner/repo format", async () => {
-    setupBasicMocks();
-
-    await downloadSkill({
-      url: testUrl,
-      global: false,
-      noop: false,
-      verbose: false,
-      gitRoot: tempDir,
-    });
-
-    const skillMd = await readFile(join(tempDir, ".claude/skills/my-skill/SKILL.md"), "utf-8");
-    // Verify _from contains owner/repo (not full URL)
-    const parsed = matter(skillMd);
-    expect(parsed.data._from).toBe("owner/repo@a1b2c3d");
-  });
-
-  it("should not inject _from when noProvenance is true", async () => {
-    setupBasicMocks();
-
+  it("should omit _from when noProvenance is true", async () => {
     await downloadSkill({
       url: testUrl,
       global: false,
@@ -255,423 +209,6 @@ describe("download command", () => {
     });
 
     const skillMd = await readFile(join(tempDir, ".claude/skills/my-skill/SKILL.md"), "utf-8");
-    // Verify raw content doesn't contain _from (avoid gray-matter cache pollution from prior tests)
     expect(skillMd).not.toContain("_from");
-  });
-
-  it("should always update _from to latest source", async () => {
-    const existingFrom = "original-owner/original-repo";
-    const newUrl = "https://github.com/other/repo/tree/main/.claude/skills/other-skill";
-
-    const otherTreeHash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-    mockFetch
-      .mockResolvedValueOnce(mockDirectoryListing([{ name: "SKILL.md", type: "file" }]))
-      .mockResolvedValueOnce(mockFileContent(`---\ndescription: My Skill\n_from: ${existingFrom}\n---\n# My Skill`))
-      // Parent directory fetch (for tree hash)
-      .mockResolvedValueOnce(
-        mockDirectoryListing([
-          {
-            name: "other-skill",
-            type: "dir",
-            path: ".claude/skills/other-skill",
-            sha: otherTreeHash,
-            download_url: null,
-          },
-        ]),
-      );
-
-    await downloadSkill({
-      url: newUrl,
-      global: false,
-      noop: false,
-      verbose: false,
-      gitRoot: tempDir,
-    });
-
-    const skillMd = await readFile(join(tempDir, ".claude/skills/other-skill/SKILL.md"), "utf-8");
-    const parsed = matter(skillMd);
-    // Should always update to the new source (with tree hash)
-    expect(parsed.data._from).toBe(`other/repo@${otherTreeHash.slice(0, 7)}`);
-    expect(skillMd).not.toContain(existingFrom);
-  });
-
-  it("should show [=] for unchanged files", async () => {
-    // Pre-create existing file with same content (including _from)
-    const skillDir = join(tempDir, ".claude/skills/my-skill");
-    await mkdir(skillDir, { recursive: true });
-    // The SKILL.md needs to already include _from (with tree hash) to be truly unchanged after injection
-    const expectedContent = matter.stringify("# My Skill", {
-      description: "My Skill",
-      _from: "owner/repo@a1b2c3d",
-    });
-    await fsWriteFile(join(skillDir, "SKILL.md"), expectedContent, "utf-8");
-    await fsWriteFile(join(skillDir, "helper.ts"), "export function helper() {}", "utf-8");
-
-    setupBasicMocks();
-
-    await downloadSkill({
-      url: testUrl,
-      global: false,
-      noop: false,
-      verbose: false,
-      gitRoot: tempDir,
-    });
-
-    const output = consoleOutput.join("\n");
-    expect(output).toContain("Unchanged");
-    expect(output).toContain("2 files unchanged");
-    expect(output).toContain("1 skill unchanged");
-  });
-
-  it("should handle binary files", async () => {
-    const binaryData = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]); // PNG header
-
-    mockFetch
-      .mockResolvedValueOnce(
-        mockDirectoryListing([
-          { name: "SKILL.md", type: "file" },
-          { name: "icon.png", type: "file" },
-        ]),
-      )
-      .mockResolvedValueOnce(mockFileContent("# Skill with icon"))
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        arrayBuffer: async () => binaryData.buffer,
-        headers: new Headers(),
-      } as Response)
-      // Parent directory fetch (for tree hash)
-      .mockResolvedValueOnce(mockParentDirResponse());
-
-    await downloadSkill({
-      url: testUrl,
-      global: false,
-      noop: false,
-      verbose: false,
-      gitRoot: tempDir,
-    });
-
-    // Check text file (SKILL.md gets _from injected with owner/repo@treeHash)
-    const skillMd = await readFile(join(tempDir, ".claude/skills/my-skill/SKILL.md"), "utf-8");
-    expect(skillMd).toContain("# Skill with icon");
-    expect(skillMd).toContain("owner/repo");
-
-    // Check binary file
-    const iconPng = await readFile(join(tempDir, ".claude/skills/my-skill/icon.png"));
-    expect(Buffer.from(iconPng).slice(0, 4)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
-  });
-
-  it("should display verbose debug information when -v is set", async () => {
-    setupBasicMocks();
-
-    await downloadSkill({
-      url: testUrl,
-      global: false,
-      noop: false,
-      verbose: true,
-      gitRoot: tempDir,
-    });
-
-    const output = consoleOutput.join("\n");
-    expect(output).toContain("DEBUG:");
-  });
-
-  it("should download to home-relative path when -g is used without destination", async () => {
-    process.env.HOME = tempDir;
-    setupBasicMocks();
-
-    await downloadSkill({
-      url: testUrl,
-      global: true,
-      noop: false,
-      verbose: false,
-      gitRoot: tempDir,
-    });
-
-    const skillMd = await readFile(join(tempDir, ".claude/skills/my-skill/SKILL.md"), "utf-8");
-    expect(skillMd).toContain("description: My Skill");
-    expect(skillMd).toContain("owner/repo");
-  });
-
-  it("should throw for invalid GitHub URLs", async () => {
-    await expect(
-      downloadSkill({
-        url: "https://gitlab.com/owner/repo",
-        global: false,
-        noop: false,
-        verbose: false,
-        gitRoot: tempDir,
-      }),
-    ).rejects.toThrow("Only GitHub URLs");
-  });
-
-  it("should propagate API errors", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 404,
-      statusText: "Not Found",
-      headers: new Headers(),
-    } as Response);
-
-    await expect(
-      downloadSkill({
-        url: testUrl,
-        global: false,
-        noop: false,
-        verbose: false,
-        gitRoot: tempDir,
-      }),
-    ).rejects.toThrow("Not found");
-  });
-
-  it("should handle blob URL pointing to SKILL.md", async () => {
-    const blobUrl = "https://github.com/owner/repo/blob/main/.claude/skills/my-skill/SKILL.md";
-
-    setupBasicMocks();
-
-    await downloadSkill({
-      url: blobUrl,
-      global: false,
-      noop: false,
-      verbose: false,
-      gitRoot: tempDir,
-    });
-
-    // Should still download to the skill directory (parent of SKILL.md)
-    const skillMd = await readFile(join(tempDir, ".claude/skills/my-skill/SKILL.md"), "utf-8");
-    expect(skillMd).toContain("description: My Skill");
-    expect(skillMd).toContain("owner/repo");
-  });
-
-  describe("repository-level download", () => {
-    const repoUrl = "https://github.com/owner/repo";
-    const repoTreeUrl = "https://github.com/owner/repo/tree/main";
-
-    function mockRepoApiResponse() {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => ({ default_branch: "main" }),
-        headers: new Headers(),
-      } as Response);
-    }
-
-    function mockTreeScanResponse(skillPaths: string[], truncated = false) {
-      const treeItems: { path: string; type: string; mode: string; sha: string; url: string }[] = [];
-      for (const skillPath of skillPaths) {
-        // Add tree entry for the skill directory (provides tree hash)
-        treeItems.push({
-          path: skillPath,
-          type: "tree",
-          mode: "040000",
-          sha: `tree-${skillPath.split("/").pop()}`,
-          url: "",
-        });
-        treeItems.push(
-          { path: `${skillPath}/SKILL.md`, type: "blob", mode: "100644", sha: "s1", url: "" },
-          { path: `${skillPath}/helper.ts`, type: "blob", mode: "100644", sha: "s2", url: "" },
-        );
-      }
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => ({ sha: "abc", url: "...", tree: treeItems, truncated }),
-        headers: new Headers(),
-      } as Response);
-    }
-
-    function mockSkillRawDownload() {
-      // fetchSkillFromTree downloads each file from raw.githubusercontent.com
-      mockFetch
-        .mockResolvedValueOnce(mockFileContent("---\ndescription: Skill\n---\n# Skill"))
-        .mockResolvedValueOnce(mockFileContent("export function helper() {}"));
-    }
-
-    it("should scan and download all skills from bare repo URL", async () => {
-      mockRepoApiResponse();
-      mockTreeScanResponse([".claude/skills/skill-a", ".claude/skills/skill-b"]);
-      mockSkillRawDownload();
-      mockSkillRawDownload();
-
-      await downloadSkill({
-        url: repoUrl,
-        global: false,
-        noop: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const skillA = await readFile(join(tempDir, ".claude/skills/skill-a/SKILL.md"), "utf-8");
-      expect(skillA).toContain("_from:");
-      expect(skillA).toContain("owner/repo");
-
-      const skillB = await readFile(join(tempDir, ".claude/skills/skill-b/SKILL.md"), "utf-8");
-      expect(skillB).toContain("_from:");
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("4 files created");
-      expect(output).toContain("2 skills created");
-    });
-
-    it("should use ref from tree URL instead of fetching default branch", async () => {
-      // No fetchDefaultBranch call — tree URL already has ref
-      mockTreeScanResponse(["skills/my-skill"]);
-      mockSkillRawDownload();
-
-      await downloadSkill({
-        url: repoTreeUrl,
-        global: false,
-        noop: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("2 files created");
-      expect(output).toContain("1 skill created");
-    });
-
-    it("should throw when no skills found in repo", async () => {
-      mockRepoApiResponse();
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => ({
-          sha: "abc",
-          url: "...",
-          tree: [{ path: "README.md", type: "blob", mode: "100644", sha: "s1", url: "" }],
-          truncated: false,
-        }),
-        headers: new Headers(),
-      } as Response);
-
-      await expect(
-        downloadSkill({ url: repoUrl, global: false, noop: false, verbose: false, gitRoot: tempDir }),
-      ).rejects.toThrow("No skills found");
-    });
-
-    it("should warn when tree is truncated", async () => {
-      mockRepoApiResponse();
-      mockTreeScanResponse(["skills/a"], true);
-      mockSkillRawDownload();
-
-      await downloadSkill({
-        url: repoUrl,
-        global: false,
-        noop: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("truncated");
-    });
-
-    it("should work in noop mode", async () => {
-      mockRepoApiResponse();
-      mockTreeScanResponse(["skills/a"]);
-      mockSkillRawDownload();
-
-      await downloadSkill({
-        url: repoUrl,
-        global: false,
-        noop: true,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("would create");
-      expect(output).toContain("Dry run complete");
-    });
-
-    it("should place skills in agent directory when destination is specified", async () => {
-      mockRepoApiResponse();
-      mockTreeScanResponse([".claude/skills/skill-a"]);
-      mockSkillRawDownload();
-
-      await downloadSkill({
-        url: repoUrl,
-        destination: "gemini",
-        global: false,
-        noop: false,
-        verbose: false,
-        gitRoot: tempDir,
-        customDirs: { gemini: tempDir },
-      });
-
-      const skillMd = await readFile(join(tempDir, "skills/skill-a/SKILL.md"), "utf-8");
-      expect(skillMd).toContain("description: Skill");
-    });
-
-    it("should continue downloading when one skill fails", async () => {
-      mockRepoApiResponse();
-      mockTreeScanResponse(["skills/bad-skill", "skills/good-skill"]);
-      // bad-skill: 404 error
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        statusText: "Not Found",
-        headers: new Headers(),
-      } as Response);
-      // good-skill: success
-      mockSkillRawDownload();
-
-      await downloadSkill({
-        url: repoUrl,
-        global: false,
-        noop: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("Skipped");
-
-      const goodSkill = await readFile(join(tempDir, "skills/good-skill/SKILL.md"), "utf-8");
-      expect(goodSkill).toContain("description: Skill");
-    });
-
-    it("should inject owner/repo provenance format", async () => {
-      mockRepoApiResponse();
-      mockTreeScanResponse([".claude/skills/skill-a"]);
-      mockSkillRawDownload();
-
-      await downloadSkill({
-        url: repoUrl,
-        global: false,
-        noop: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const skillMd = await readFile(join(tempDir, ".claude/skills/skill-a/SKILL.md"), "utf-8");
-      expect(skillMd).toContain("_from:");
-      expect(skillMd).toContain("owner/repo");
-      expect(skillMd).not.toContain("https://github.com");
-    });
-  });
-
-  // ── formatFromValue ─────────────────────────────────────────────
-
-  describe("formatFromValue", () => {
-    it("should return owner/repo when no treeHash", () => {
-      expect(formatFromValue("owner/repo")).toBe("owner/repo");
-      expect(formatFromValue("owner/repo", undefined)).toBe("owner/repo");
-    });
-
-    it("should use short hash (7 chars) by default", () => {
-      const fullHash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
-      expect(formatFromValue("owner/repo", fullHash)).toBe("owner/repo@a1b2c3d");
-    });
-
-    it("should use full hash when fullHash=true", () => {
-      const fullHash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
-      expect(formatFromValue("owner/repo", fullHash, true)).toBe(`owner/repo@${fullHash}`);
-    });
-
-    it("should handle hash shorter than 7 chars", () => {
-      expect(formatFromValue("owner/repo", "abc")).toBe("owner/repo@abc");
-    });
   });
 });

--- a/tests/cli/update.test.ts
+++ b/tests/cli/update.test.ts
@@ -2,12 +2,33 @@ import { writeFile as fsWriteFile, mkdir, readFile, rm } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import matter from "gray-matter";
-import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DiscoveredSkill } from "../../src/utils/github-utils.js";
+
+vi.mock("../../src/utils/git-repo-cache.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/utils/git-repo-cache.js")>();
+  return {
+    ...actual,
+    ensureGitHubRepoCache: vi.fn(),
+    listSkillsAtRef: vi.fn(),
+    readSkillFilesAtCommit: vi.fn(),
+    resolveCommitForPath: vi.fn(),
+    resolveDefaultBranch: vi.fn(),
+    resolveTreeHashAtCommit: vi.fn(),
+  };
+});
+
 import { hashesMatch, parseFromValue, updateSkills } from "../../src/cli/update.js";
+import {
+  ensureGitHubRepoCache,
+  listSkillsAtRef,
+  readSkillFilesAtCommit,
+  resolveCommitForPath,
+  resolveDefaultBranch,
+  resolveTreeHashAtCommit,
+} from "../../src/utils/git-repo-cache.js";
 
 describe("update command", () => {
-  let originalFetch: typeof globalThis.fetch;
-  let mockFetch: Mock;
   let tempDir: string;
   let consoleOutput: string[];
 
@@ -17,37 +38,42 @@ describe("update command", () => {
     tempDir = join(tmpdir(), `update-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     await mkdir(tempDir, { recursive: true });
 
-    originalFetch = globalThis.fetch;
-    mockFetch = vi.fn();
-    globalThis.fetch = mockFetch;
-
     consoleOutput = [];
     vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
       consoleOutput.push(args.join(" "));
     });
+
+    vi.mocked(ensureGitHubRepoCache).mockResolvedValue({ owner: "owner", repo: "repo", dir: "/cache/repo.git" });
+    vi.mocked(resolveDefaultBranch).mockResolvedValue("main");
+    vi.mocked(resolveCommitForPath).mockResolvedValue("eligible-commit");
+    vi.mocked(resolveTreeHashAtCommit).mockImplementation(async (_repoDir, commitSha) =>
+      commitSha === "eligible-commit"
+        ? "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        : "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    vi.mocked(readSkillFilesAtCommit).mockResolvedValue([
+      { relativePath: "SKILL.md", content: "---\ndescription: Updated Skill\n---\n# Updated", isBinary: false },
+      { relativePath: "helper.ts", content: "export const updated = true;", isBinary: false },
+    ]);
+    vi.mocked(listSkillsAtRef).mockResolvedValue([
+      {
+        name: "my-skill",
+        path: ".claude/skills/my-skill",
+        files: [".claude/skills/my-skill/SKILL.md", ".claude/skills/my-skill/helper.ts"],
+        treeHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      },
+    ]);
   });
 
   afterEach(async () => {
-    globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  // ── Helpers ─────────────────────────────────────────────────────
-
-  const treeHash1 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-  const treeHash2 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-
-  /** Create a local skill directory with a SKILL.md containing _from */
-  async function createLocalSkill(
-    relativePath: string,
-    skillName: string,
-    fromValue?: string,
-    description = "Test Skill",
-  ): Promise<string> {
+  async function createLocalSkill(relativePath: string, skillName: string, fromValue?: string): Promise<string> {
     const skillDir = join(tempDir, relativePath, skillName);
     await mkdir(skillDir, { recursive: true });
-    const frontmatter: Record<string, unknown> = { description };
+    const frontmatter: Record<string, unknown> = { description: "Test Skill" };
     if (fromValue !== undefined) {
       frontmatter._from = fromValue;
     }
@@ -56,547 +82,155 @@ describe("update command", () => {
     return skillDir;
   }
 
-  /** Mock fetchDefaultBranch response */
-  function mockDefaultBranch(branch = "main"): void {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({ default_branch: branch }),
-      headers: new Headers(),
-    } as Response);
-  }
-
-  /** Mock scanRepositoryForSkills response */
-  function mockTreeScan(skills: { name: string; path: string; treeHash?: string }[], truncated = false): void {
-    const treeItems: { path: string; type: string; mode: string; sha: string; url: string }[] = [];
-    for (const skill of skills) {
-      treeItems.push({
-        path: skill.path,
-        type: "tree",
-        mode: "040000",
-        sha: skill.treeHash ?? `tree-${skill.name}`,
-        url: "",
-      });
-      treeItems.push({
-        path: `${skill.path}/SKILL.md`,
-        type: "blob",
-        mode: "100644",
-        sha: "s1",
-        url: "",
-      });
-    }
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => ({ sha: "abc", url: "...", tree: treeItems, truncated }),
-      headers: new Headers(),
-    } as Response);
-  }
-
-  /** Mock fetchSkillFromTree raw download */
-  function mockSkillRawDownload(description = "Updated Skill"): void {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      text: async () => `---\ndescription: ${description}\n---\n# Updated`,
-      arrayBuffer: async () => new TextEncoder().encode(`---\ndescription: ${description}\n---\n# Updated`).buffer,
-      headers: new Headers(),
-    } as Response);
-  }
-
-  // ── parseFromValue ────────────────────────────────────────────
-
   describe("parseFromValue", () => {
     it("should parse owner/repo@treeHash format", () => {
-      const result = parseFromValue(`owner/repo@${treeHash1}`);
-      expect(result).toEqual({ ownerRepo: "owner/repo", treeHash: treeHash1 });
+      expect(parseFromValue("owner/repo@abc123")).toEqual({ ownerRepo: "owner/repo", treeHash: "abc123" });
     });
 
-    it("should parse owner/repo without hash → empty string treeHash", () => {
-      const result = parseFromValue("owner/repo");
-      expect(result).toEqual({ ownerRepo: "owner/repo", treeHash: "" });
-    });
-
-    it("should parse truncated/short hex hash after @", () => {
-      const result = parseFromValue("owner/repo@5c2");
-      expect(result).toEqual({ ownerRepo: "owner/repo", treeHash: "5c2" });
-    });
-
-    it("should not split on @ that is not followed by hex", () => {
-      const result = parseFromValue("owner/repo@not-a-hash");
-      expect(result).toEqual({ ownerRepo: "owner/repo@not-a-hash", treeHash: "" });
-    });
-
-    it("should handle @ at position 0 as no hash", () => {
-      const result = parseFromValue(`@${treeHash1}`);
-      expect(result).toEqual({ ownerRepo: `@${treeHash1}`, treeHash: "" });
+    it("should treat non-hex suffixes as part of owner/repo", () => {
+      expect(parseFromValue("owner/repo@not-a-hash")).toEqual({ ownerRepo: "owner/repo@not-a-hash", treeHash: "" });
     });
   });
-
-  // ── hashesMatch ─────────────────────────────────────────────
 
   describe("hashesMatch", () => {
-    it("should match identical full hashes", () => {
-      expect(hashesMatch(treeHash1, treeHash1)).toBe(true);
+    it("should match short and full hashes by prefix", () => {
+      expect(hashesMatch("aaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")).toBe(true);
     });
 
-    it("should match short hash against full hash", () => {
-      expect(hashesMatch(treeHash1.slice(0, 7), treeHash1)).toBe(true);
-      expect(hashesMatch(treeHash1, treeHash1.slice(0, 7))).toBe(true);
-    });
-
-    it("should not match different hashes", () => {
-      expect(hashesMatch(treeHash1, treeHash2)).toBe(false);
-      expect(hashesMatch(treeHash1.slice(0, 7), treeHash2)).toBe(false);
-    });
-
-    it("should return false when either hash is empty", () => {
-      expect(hashesMatch("", treeHash1)).toBe(false);
-      expect(hashesMatch(treeHash1, "")).toBe(false);
-      expect(hashesMatch("", "")).toBe(false);
+    it("should return false for empty hashes", () => {
+      expect(hashesMatch("", "aaaaaaaa")).toBe(false);
     });
   });
 
-  // ── No argument: scan agent directories ───────────────────────
-
-  describe("no argument (agent directory scan)", () => {
-    it("should show message when no skills with _from exist", async () => {
-      await updateSkills({
-        noop: false,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("No skills with _from provenance found");
+  it("should show a message when no skills with _from exist", async () => {
+    await updateSkills({
+      noop: false,
+      global: false,
+      verbose: false,
+      gitRoot: tempDir,
     });
 
-    it("should skip skills without _from", async () => {
-      await createLocalSkill(".claude/skills", "no-from-skill", undefined);
-
-      await updateSkills({
-        noop: false,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("No skills with _from provenance found");
-    });
-
-    it("should find skills in agent directories", async () => {
-      await createLocalSkill(".claude/skills", "my-skill", `owner/repo@${treeHash1}`);
-
-      mockDefaultBranch();
-      mockTreeScan([{ name: "my-skill", path: ".claude/skills/my-skill", treeHash: treeHash1 }]);
-
-      await updateSkills({
-        noop: false,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("No upstream changes");
-    });
-
-    it("should scan skills across different agent directories", async () => {
-      await createLocalSkill(".claude/skills", "skill-c", `owner/repo@${treeHash1}`);
-      await createLocalSkill(".gemini/skills", "skill-g", `owner/repo@${treeHash1}`);
-
-      mockDefaultBranch();
-      mockTreeScan([
-        { name: "skill-c", path: ".claude/skills/skill-c", treeHash: treeHash1 },
-        { name: "skill-g", path: ".gemini/skills/skill-g", treeHash: treeHash2 },
-      ]);
-      mockSkillRawDownload();
-
-      await updateSkills({
-        noop: false,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("skill-c");
-      expect(output).toContain("No upstream changes");
-      expect(output).toContain("skill-g");
-      expect(output).toContain("Updated");
-    });
-
-    it("should scan cwd-based project directories when gitRoot is null", async () => {
-      const originalCwd = process.cwd();
-      process.chdir(tempDir);
-
-      try {
-        await createLocalSkill(".claude/skills", "cwd-skill", `owner/repo@${treeHash1}`);
-
-        mockDefaultBranch();
-        mockTreeScan([{ name: "cwd-skill", path: ".claude/skills/cwd-skill", treeHash: treeHash1 }]);
-
-        await updateSkills({
-          noop: false,
-          global: false,
-          verbose: false,
-          gitRoot: null,
-        });
-      } finally {
-        process.chdir(originalCwd);
-      }
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("cwd-skill");
-      expect(output).toContain("No upstream changes");
-    });
+    expect(consoleOutput.join("\n")).toContain("No skills with _from provenance found");
   });
 
-  // ── With skill-path argument ──────────────────────────────────
+  it("should report already eligible when the local tree already matches the eligible tree", async () => {
+    await createLocalSkill(".claude/skills", "my-skill", "owner/repo@bbbbbbb");
 
-  describe("with skill-path argument", () => {
-    it("should find a single skill by direct path", async () => {
-      await createLocalSkill("skills", "skill-creator", `anthropics/skills@${treeHash1}`);
-
-      mockDefaultBranch();
-      mockTreeScan([{ name: "skill-creator", path: "skills/skill-creator", treeHash: treeHash1 }]);
-
-      await updateSkills({
-        skillPath: "skills/skill-creator",
-        noop: true,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("skill-creator");
-      expect(output).toContain("No upstream changes");
+    await updateSkills({
+      noop: false,
+      global: false,
+      verbose: false,
+      gitRoot: tempDir,
     });
 
-    it("should find multiple skills under a parent directory", async () => {
-      await createLocalSkill("skills", "skill-a", `owner/repo@${treeHash1}`);
-      await createLocalSkill("skills", "skill-b", `owner/repo@${treeHash1}`);
-
-      mockDefaultBranch();
-      mockTreeScan([
-        { name: "skill-a", path: "skills/skill-a", treeHash: treeHash1 },
-        { name: "skill-b", path: "skills/skill-b", treeHash: treeHash2 },
-      ]);
-      mockSkillRawDownload();
-
-      await updateSkills({
-        skillPath: "skills",
-        noop: false,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("skill-a");
-      expect(output).toContain("No upstream changes");
-      expect(output).toContain("skill-b");
-      expect(output).toContain("Updated");
-    });
-
-    it("should show message when no skills found under path", async () => {
-      await mkdir(join(tempDir, "empty-dir"), { recursive: true });
-
-      await updateSkills({
-        skillPath: "empty-dir",
-        noop: false,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain('No skills with _from provenance found under "empty-dir"');
-    });
-
-    it("should update skill at a deep path and write new _from", async () => {
-      await createLocalSkill("some/deep/path", "my-skill", `owner/repo@${treeHash1}`);
-
-      mockDefaultBranch();
-      mockTreeScan([{ name: "my-skill", path: "some/deep/path/my-skill", treeHash: treeHash2 }]);
-      mockSkillRawDownload();
-
-      await updateSkills({
-        skillPath: "some/deep/path/my-skill",
-        noop: false,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("Updated");
-
-      const skillMd = await readFile(join(tempDir, "some/deep/path/my-skill/SKILL.md"), "utf-8");
-      const parsed = matter(skillMd);
-      expect(parsed.data._from).toBe(`owner/repo@${treeHash2.slice(0, 7)}`);
-    });
-
-    it("should resolve skillPath from cwd when gitRoot is null", async () => {
-      const originalCwd = process.cwd();
-      process.chdir(tempDir);
-
-      try {
-        await createLocalSkill("skills", "cwd-path-skill", `owner/repo@${treeHash1}`);
-
-        mockDefaultBranch();
-        mockTreeScan([{ name: "cwd-path-skill", path: "skills/cwd-path-skill", treeHash: treeHash1 }]);
-
-        await updateSkills({
-          skillPath: "skills/cwd-path-skill",
-          noop: true,
-          global: false,
-          verbose: false,
-          gitRoot: null,
-        });
-      } finally {
-        process.chdir(originalCwd);
-      }
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("cwd-path-skill");
-      expect(output).toContain("No upstream changes");
-    });
+    expect(consoleOutput.join("\n")).toContain("Already eligible");
   });
 
-  // ── Tree hash comparison ──────────────────────────────────────
+  it("should update the skill and refresh _from when the eligible tree changed", async () => {
+    await createLocalSkill(".claude/skills", "my-skill", "owner/repo@aaaaaaa");
+    vi.mocked(listSkillsAtRef).mockResolvedValue([
+      {
+        name: "my-skill",
+        path: ".claude/skills/my-skill",
+        files: [".claude/skills/my-skill/SKILL.md", ".claude/skills/my-skill/helper.ts"],
+        treeHash: "cccccccccccccccccccccccccccccccccccccccc",
+      },
+    ]);
 
-  describe("tree hash comparison", () => {
-    it("should show 'Up to date' when tree hash matches", async () => {
-      await createLocalSkill(".claude/skills", "my-skill", `owner/repo@${treeHash1}`);
-
-      mockDefaultBranch();
-      mockTreeScan([{ name: "my-skill", path: ".claude/skills/my-skill", treeHash: treeHash1 }]);
-
-      await updateSkills({
-        noop: false,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("No upstream changes");
-      expect(output).toContain("1 unchanged");
+    await updateSkills({
+      noop: false,
+      global: false,
+      verbose: false,
+      gitRoot: tempDir,
     });
 
-    it("should update when tree hash differs", async () => {
-      await createLocalSkill(".claude/skills", "my-skill", `owner/repo@${treeHash1}`);
+    const skillMd = await readFile(join(tempDir, ".claude/skills/my-skill/SKILL.md"), "utf-8");
+    const helper = await readFile(join(tempDir, ".claude/skills/my-skill/helper.ts"), "utf-8");
+    const parsed = matter(skillMd);
 
-      mockDefaultBranch();
-      mockTreeScan([{ name: "my-skill", path: ".claude/skills/my-skill", treeHash: treeHash2 }]);
-      mockSkillRawDownload();
-
-      await updateSkills({
-        noop: false,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("Updated");
-      expect(output).toContain("1 skill updated");
-
-      const skillMd = await readFile(join(tempDir, ".claude/skills/my-skill/SKILL.md"), "utf-8");
-      const parsed = matter(skillMd);
-      expect(parsed.data._from).toBe(`owner/repo@${treeHash2.slice(0, 7)}`);
-    });
-
-    it("should update when local tree hash is non-existent (invalid but valid hex format)", async () => {
-      const fakeHash = "0000000000000000000000000000000000000000";
-      await createLocalSkill(".claude/skills", "my-skill", `owner/repo@${fakeHash}`);
-
-      mockDefaultBranch();
-      mockTreeScan([{ name: "my-skill", path: ".claude/skills/my-skill", treeHash: treeHash1 }]);
-      mockSkillRawDownload();
-
-      await updateSkills({
-        noop: false,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("Updated");
-      expect(output).toContain("1 skill updated");
-
-      const skillMd = await readFile(join(tempDir, ".claude/skills/my-skill/SKILL.md"), "utf-8");
-      const parsed = matter(skillMd);
-      expect(parsed.data._from).toBe(`owner/repo@${treeHash1.slice(0, 7)}`);
-    });
-
-    it("should force download when no local tree hash (legacy _from)", async () => {
-      await createLocalSkill(".claude/skills", "my-skill", "owner/repo");
-
-      mockDefaultBranch();
-      mockTreeScan([{ name: "my-skill", path: ".claude/skills/my-skill", treeHash: treeHash1 }]);
-      mockSkillRawDownload();
-
-      await updateSkills({
-        noop: false,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("Updated");
-
-      const skillMd = await readFile(join(tempDir, ".claude/skills/my-skill/SKILL.md"), "utf-8");
-      const parsed = matter(skillMd);
-      expect(parsed.data._from).toBe(`owner/repo@${treeHash1.slice(0, 7)}`);
-    });
-
-    it("should match short hash against full remote hash", async () => {
-      // Local has short hash, remote has full hash — should match
-      const shortHash = treeHash1.slice(0, 7);
-      await createLocalSkill(".claude/skills", "my-skill", `owner/repo@${shortHash}`);
-
-      mockDefaultBranch();
-      mockTreeScan([{ name: "my-skill", path: ".claude/skills/my-skill", treeHash: treeHash1 }]);
-
-      await updateSkills({
-        noop: false,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("No upstream changes");
-    });
+    expect(parsed.data._from).toBe("owner/repo@bbbbbbb");
+    expect(helper).toBe("export const updated = true;");
+    expect(consoleOutput.join("\n")).toContain("Updated");
   });
 
-  // ── Noop mode ─────────────────────────────────────────────────
+  it("should report re-pinned when local matches HEAD but min-age selects an older eligible tree", async () => {
+    await createLocalSkill(".claude/skills", "my-skill", "owner/repo@aaaaaaa");
+    vi.mocked(resolveCommitForPath).mockImplementation(async (_repoDir, _ref, _path, minAge) =>
+      minAge === undefined ? "head-commit" : "eligible-commit",
+    );
 
-  describe("noop mode", () => {
-    it("should not write files in noop mode", async () => {
-      await createLocalSkill(".claude/skills", "my-skill", `owner/repo@${treeHash1}`);
-
-      mockDefaultBranch();
-      mockTreeScan([{ name: "my-skill", path: ".claude/skills/my-skill", treeHash: treeHash2 }]);
-
-      await updateSkills({
-        noop: true,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("Update available");
-      expect(output).toContain("1 update available");
-      expect(output).toContain("Dry run complete");
-
-      const skillMd = await readFile(join(tempDir, ".claude/skills/my-skill/SKILL.md"), "utf-8");
-      const parsed = matter(skillMd);
-      expect(parsed.data._from).toBe(`owner/repo@${treeHash1}`);
+    await updateSkills({
+      noop: false,
+      global: false,
+      verbose: false,
+      gitRoot: tempDir,
+      minAge: 14,
     });
+
+    expect(consoleOutput.join("\n")).toContain("Re-pinned");
   });
 
-  // ── Not found / errors ────────────────────────────────────────
+  it("should skip with a warning when no eligible version exists", async () => {
+    await createLocalSkill(".claude/skills", "my-skill", "owner/repo@aaaaaaa");
+    vi.mocked(resolveCommitForPath).mockResolvedValue(null);
 
-  describe("not found in remote", () => {
-    it("should show warning when skill not found in remote repo", async () => {
-      await createLocalSkill(".claude/skills", "my-skill", `owner/repo@${treeHash1}`);
+    await updateSkills({
+      noop: false,
+      global: false,
+      verbose: false,
+      gitRoot: tempDir,
+      minAge: 30,
+    });
 
-      mockDefaultBranch();
-      mockTreeScan([]);
+    expect(consoleOutput.join("\n")).toContain("no eligible version found");
+  });
+
+  it("should skip duplicate remote skill names because path provenance is not stored", async () => {
+    await createLocalSkill(".claude/skills", "my-skill", "owner/repo@aaaaaaa");
+    const duplicateSkills: DiscoveredSkill[] = [
+      {
+        name: "my-skill",
+        path: ".claude/skills/my-skill",
+        files: [".claude/skills/my-skill/SKILL.md"],
+        treeHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      },
+      {
+        name: "my-skill",
+        path: ".gemini/skills/my-skill",
+        files: [".gemini/skills/my-skill/SKILL.md"],
+        treeHash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      },
+    ];
+    vi.mocked(listSkillsAtRef).mockResolvedValue(duplicateSkills);
+
+    await updateSkills({
+      noop: false,
+      global: false,
+      verbose: false,
+      gitRoot: tempDir,
+    });
+
+    expect(consoleOutput.join("\n")).toContain("multiple remote skills share this name");
+  });
+
+  it("should resolve skillPath relative to cwd when gitRoot is null", async () => {
+    const originalCwd = process.cwd();
+    process.chdir(tempDir);
+
+    try {
+      await createLocalSkill(".claude/skills", "my-skill", "owner/repo@bbbbbbb");
 
       await updateSkills({
+        skillPath: ".claude/skills/my-skill",
         noop: false,
         global: false,
         verbose: false,
-        gitRoot: tempDir,
+        gitRoot: null,
       });
+    } finally {
+      process.chdir(originalCwd);
+    }
 
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("Not found in remote");
-      expect(output).toContain("1 not found");
-    });
-  });
-
-  describe("API errors", () => {
-    it("should handle repo-level API error gracefully", async () => {
-      await createLocalSkill(".claude/skills", "my-skill", `owner/repo@${treeHash1}`);
-
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        statusText: "Not Found",
-        headers: new Headers(),
-      } as Response);
-
-      await updateSkills({
-        noop: false,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("Error");
-      expect(output).toContain("1 error");
-    });
-  });
-
-  // ── Multiple repos ────────────────────────────────────────────
-
-  describe("multiple repos", () => {
-    it("should group skills by owner/repo and batch API calls", async () => {
-      await createLocalSkill(".claude/skills", "skill-a", `owner/repo-a@${treeHash1}`);
-      await createLocalSkill(".claude/skills", "skill-b", `other/repo-b@${treeHash1}`);
-
-      mockDefaultBranch();
-      mockTreeScan([{ name: "skill-a", path: ".claude/skills/skill-a", treeHash: treeHash1 }]);
-
-      mockDefaultBranch();
-      mockTreeScan([{ name: "skill-b", path: ".claude/skills/skill-b", treeHash: treeHash2 }]);
-      mockSkillRawDownload();
-
-      await updateSkills({
-        noop: false,
-        global: false,
-        verbose: false,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("owner/repo-a");
-      expect(output).toContain("other/repo-b");
-      expect(output).toContain("No upstream changes");
-      expect(output).toContain("Updated");
-    });
-  });
-
-  // ── Verbose mode ──────────────────────────────────────────────
-
-  describe("verbose mode", () => {
-    it("should show debug info in verbose mode", async () => {
-      await createLocalSkill(".claude/skills", "my-skill", `owner/repo@${treeHash1}`);
-
-      mockDefaultBranch();
-      mockTreeScan([{ name: "my-skill", path: ".claude/skills/my-skill", treeHash: treeHash1 }]);
-
-      await updateSkills({
-        noop: false,
-        global: false,
-        verbose: true,
-        gitRoot: tempDir,
-      });
-
-      const output = consoleOutput.join("\n");
-      expect(output).toContain("DEBUG:");
-    });
+    expect(consoleOutput.join("\n")).toContain("Already eligible");
   });
 });

--- a/tests/integration/min-age-cache.test.ts
+++ b/tests/integration/min-age-cache.test.ts
@@ -1,0 +1,157 @@
+import { execFile } from "node:child_process";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import matter from "gray-matter";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { downloadSkill } from "../../src/cli/download.js";
+import { updateSkills } from "../../src/cli/update.js";
+import { getRepoCacheDir, resolveTreeHashAtCommit } from "../../src/utils/git-repo-cache.js";
+
+const execFileAsync = promisify(execFile);
+
+describe("min-age cache integration", () => {
+  let tempDir: string;
+  let workRepoDir: string;
+  let remoteRootDir: string;
+  let bareRemoteDir: string;
+  let homeDir: string;
+  let cacheDir: string;
+  let projectDir: string;
+  let gitConfigPath: string;
+  let originalHome: string | undefined;
+  let originalXdgCacheHome: string | undefined;
+  let originalGitConfigGlobal: string | undefined;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-25T00:00:00Z"));
+
+    tempDir = join(tmpdir(), `min-age-cache-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    workRepoDir = join(tempDir, "work-repo");
+    remoteRootDir = join(tempDir, "remote-root");
+    bareRemoteDir = join(remoteRootDir, "owner", "repo.git");
+    homeDir = join(tempDir, "home");
+    cacheDir = join(tempDir, "cache");
+    projectDir = join(tempDir, "project");
+    gitConfigPath = join(homeDir, ".gitconfig");
+
+    await mkdir(workRepoDir, { recursive: true });
+    await mkdir(join(remoteRootDir, "owner"), { recursive: true });
+    await mkdir(homeDir, { recursive: true });
+    await mkdir(cacheDir, { recursive: true });
+    await mkdir(projectDir, { recursive: true });
+
+    originalHome = process.env.HOME;
+    originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+    originalGitConfigGlobal = process.env.GIT_CONFIG_GLOBAL;
+    process.env.HOME = homeDir;
+    process.env.XDG_CACHE_HOME = cacheDir;
+    process.env.GIT_CONFIG_GLOBAL = gitConfigPath;
+
+    await execFileAsync("git", ["init", "-b", "main"], { cwd: workRepoDir });
+    await execFileAsync("git", ["config", "user.name", "Test User"], { cwd: workRepoDir });
+    await execFileAsync("git", ["config", "user.email", "test@example.com"], { cwd: workRepoDir });
+    await execFileAsync(
+      "git",
+      ["config", "--global", `url.file://${remoteRootDir}/.insteadOf`, "https://github.com/"],
+      {
+        cwd: workRepoDir,
+        env: process.env,
+      },
+    );
+
+    await writeSkillVersion("v1", "2024-01-01T00:00:00Z");
+    await writeSkillVersion("v2", "2024-01-10T00:00:00Z");
+    await writeSkillVersion("v3", "2024-01-20T00:00:00Z");
+
+    await execFileAsync("git", ["clone", "--bare", workRepoDir, bareRemoteDir]);
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+
+    if (originalHome === undefined) {
+      process.env.HOME = undefined;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    if (originalXdgCacheHome === undefined) {
+      process.env.XDG_CACHE_HOME = undefined;
+    } else {
+      process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+    }
+
+    if (originalGitConfigGlobal === undefined) {
+      process.env.GIT_CONFIG_GLOBAL = undefined;
+    } else {
+      process.env.GIT_CONFIG_GLOBAL = originalGitConfigGlobal;
+    }
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function writeSkillVersion(version: string, isoDate: string): Promise<void> {
+    const skillDir = join(workRepoDir, ".claude", "skills", "demo");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), `---\ndescription: ${version}\n---\n# Demo ${version}\n`, "utf-8");
+    await writeFile(join(skillDir, "helper.ts"), `export const version = "${version}";\n`, "utf-8");
+    await execFileAsync("git", ["add", "."], { cwd: workRepoDir });
+    await execFileAsync("git", ["commit", "-m", `feat: ${version}`], {
+      cwd: workRepoDir,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_DATE: isoDate,
+        GIT_COMMITTER_DATE: isoDate,
+      },
+    });
+  }
+
+  it("should add from HEAD through the bare cache and re-pin on update --min-age", async () => {
+    const skillUrl = "https://github.com/owner/repo/tree/main/.claude/skills/demo";
+
+    await downloadSkill({
+      url: skillUrl,
+      global: false,
+      noop: false,
+      verbose: false,
+      gitRoot: projectDir,
+    });
+
+    const skillMdPath = join(projectDir, ".claude", "skills", "demo", "SKILL.md");
+    const helperPath = join(projectDir, ".claude", "skills", "demo", "helper.ts");
+    const initialSkill = matter(await readFile(skillMdPath, "utf-8"));
+    expect(initialSkill.data._from).toBeDefined();
+    expect(String(initialSkill.data._from)).toMatch(/^owner\/repo@[0-9a-f]{7}$/);
+    expect(await readFile(helperPath, "utf-8")).toContain('version = "v3"');
+
+    const headCommit = (await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: workRepoDir })).stdout.trim();
+    const olderCommit = (
+      await execFileAsync("git", ["rev-list", "--max-count=1", "--before=2024-01-16T00:00:00Z", "HEAD"], {
+        cwd: workRepoDir,
+      })
+    ).stdout.trim();
+    const expectedHeadTree = await resolveTreeHashAtCommit(workRepoDir, headCommit, ".claude/skills/demo");
+    const expectedEligibleTree = await resolveTreeHashAtCommit(workRepoDir, olderCommit, ".claude/skills/demo");
+
+    expect(initialSkill.data._from).toBe(`owner/repo@${expectedHeadTree?.slice(0, 7)}`);
+
+    const cacheRepoDir = getRepoCacheDir("owner", "repo");
+    expect(cacheRepoDir).toBe(join(cacheDir, "agent-skill-porter", "repos", "owner_repo.git"));
+    await expect(readFile(join(cacheRepoDir, "HEAD"), "utf-8")).resolves.toContain("refs");
+
+    await updateSkills({
+      noop: false,
+      global: false,
+      verbose: false,
+      gitRoot: projectDir,
+      minAge: 10,
+    });
+
+    const updatedSkill = matter(await readFile(skillMdPath, "utf-8"));
+    expect(updatedSkill.data._from).toBe(`owner/repo@${expectedEligibleTree?.slice(0, 7)}`);
+    expect(await readFile(helperPath, "utf-8")).toContain('version = "v2"');
+  });
+});

--- a/tests/utils/git-repo-cache.test.ts
+++ b/tests/utils/git-repo-cache.test.ts
@@ -1,0 +1,109 @@
+import { execFile } from "node:child_process";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getRepoCacheDir,
+  listSkillsAtRef,
+  readSkillFilesAtCommit,
+  resolveCommitForPath,
+  resolveTreeHashAtCommit,
+} from "../../src/utils/git-repo-cache.js";
+
+const execFileAsync = promisify(execFile);
+
+describe("git-repo-cache", () => {
+  let repoDir: string;
+
+  beforeEach(async () => {
+    repoDir = join(tmpdir(), `git-repo-cache-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(repoDir, { recursive: true });
+
+    await execFileAsync("git", ["init", "-b", "main"], { cwd: repoDir });
+    await execFileAsync("git", ["config", "user.name", "Test User"], { cwd: repoDir });
+    await execFileAsync("git", ["config", "user.email", "test@example.com"], { cwd: repoDir });
+
+    await writeRepoFile(".claude/skills/demo/SKILL.md", "---\ndescription: v1\n---\n# Demo");
+    await writeRepoFile(".claude/skills/demo/helper.ts", "export const version = 1;\n");
+    await commitAll("2024-01-01T00:00:00Z", "feat: initial skill");
+
+    await writeRepoFile(".claude/skills/demo/SKILL.md", "---\ndescription: v2\n---\n# Demo");
+    await writeRepoFile(".claude/skills/demo/helper.ts", "export const version = 2;\n");
+    await commitAll("2024-01-15T00:00:00Z", "feat: update skill");
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await rm(repoDir, { recursive: true, force: true });
+  });
+
+  async function writeRepoFile(relativePath: string, content: string): Promise<void> {
+    const filePath = join(repoDir, relativePath);
+    await mkdir(join(filePath, ".."), { recursive: true });
+    await writeFile(filePath, content, "utf-8");
+  }
+
+  async function commitAll(isoDate: string, message: string): Promise<void> {
+    await execFileAsync("git", ["add", "."], { cwd: repoDir });
+    await execFileAsync("git", ["commit", "-m", message], {
+      cwd: repoDir,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_DATE: isoDate,
+        GIT_COMMITTER_DATE: isoDate,
+      },
+    });
+  }
+
+  it("should normalize owner and repo names in the cache directory key", () => {
+    const cacheDir = getRepoCacheDir("Owner", "Repo");
+    expect(cacheDir).toContain("owner_repo.git");
+  });
+
+  it("should list skills at a ref with tree hashes", async () => {
+    const skills = await listSkillsAtRef(repoDir, "HEAD");
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].path).toBe(".claude/skills/demo");
+    expect(skills[0].files).toContain(".claude/skills/demo/SKILL.md");
+    expect(skills[0].treeHash).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("should resolve eligible commits using committer date", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-20T00:00:00Z"));
+
+    const recentEligible = await resolveCommitForPath(repoDir, "HEAD", ".claude/skills/demo", 3);
+    const olderEligible = await resolveCommitForPath(repoDir, "HEAD", ".claude/skills/demo", 10);
+
+    expect(recentEligible).toMatch(/^[0-9a-f]{40}$/);
+    expect(olderEligible).toMatch(/^[0-9a-f]{40}$/);
+    expect(recentEligible).not.toBe(olderEligible);
+  });
+
+  it("should resolve the tree hash for a specific commit and path", async () => {
+    const commit = await resolveCommitForPath(repoDir, "HEAD", ".claude/skills/demo");
+    const treeHash = await resolveTreeHashAtCommit(repoDir, commit ?? "", ".claude/skills/demo");
+
+    expect(treeHash).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("should read skill files from an older eligible commit", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-20T00:00:00Z"));
+
+    const olderCommit = await resolveCommitForPath(repoDir, "HEAD", ".claude/skills/demo", 10);
+    const files = await readSkillFilesAtCommit(repoDir, olderCommit ?? "", ".claude/skills/demo");
+    const skillFile = files.find((file) => file.relativePath === "SKILL.md");
+
+    expect(skillFile).toBeDefined();
+    expect(typeof skillFile?.content).toBe("string");
+    expect(String(skillFile?.content)).toContain("description: v1");
+
+    const helperPath = join(repoDir, ".claude/skills/demo/helper.ts");
+    const currentContent = await readFile(helperPath, "utf-8");
+    expect(currentContent).toContain("version = 2");
+  });
+});


### PR DESCRIPTION
## Summary
- add git-history-based min-age resolution for add/download/update
- unify skill fetching through bare repo cache and explicit committer timestamp filtering
- add cache/integration tests for add -> update --min-age re-pin flow

## Verification
- pnpm verify
- pnpm build